### PR TITLE
Startup crash fix.

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -101,6 +101,7 @@ BOOL dontUseNarrowLayout = NO;
 
         NSMutableDictionary *defaultItemsForToolbarSize = [self valueForKey:@"_defaultItemsForToolbarSize"];
         if (defaultItemsForToolbarSize) {
+            [self setValue:addTabItem forKey:@"_addTabItem"];
             [MSHookIvar<NSMutableDictionary *>(self, "_defaultItemsForToolbarSize")[@([self toolbarSize])] addObject:[self valueForKey:@"_addTabItem"]];
         }
     }


### PR DESCRIPTION
In some iOS version (iOS 8 for example), Safari will crash on startup because the code was trying to add a “null” add tab item. Setting it right as ivar makes things fine.